### PR TITLE
Zero-pad numeric fields if input is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.2.0
+
+* Numeric fields can be nil to zero-pad
+
 ## v0.0.8
 
 * Strip line endings from fields in record.

--- a/lib/fixy/formatter/numeric.rb
+++ b/lib/fixy/formatter/numeric.rb
@@ -9,11 +9,14 @@ module Fixy
       #
 
       def format_numeric(input, length)
-        input = input.to_s
-        raise ArgumentError, "Invalid Input (only digits are accepted) (input: #{input})" unless input =~ /^\d+$/
-        raise ArgumentError, "Not enough length (input: #{input}, length: #{length})" if input.length > length
+        input_as_string = input.to_s
 
-        input.rjust(length, '0')
+        unless input.nil?
+          raise ArgumentError, "Invalid Input (only digits are accepted) (input: #{input})" unless input_as_string =~ /^\d+$/
+          raise ArgumentError, "Not enough length (input: #{input}, length: #{length})" if input_as_string.length > length
+        end
+
+        input_as_string.rjust(length, '0')
       end
     end
   end

--- a/lib/fixy/version.rb
+++ b/lib/fixy/version.rb
@@ -1,3 +1,3 @@
 module Fixy
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end

--- a/spec/fixy/formatter/numeric_spec.rb
+++ b/spec/fixy/formatter/numeric_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe Fixy::Formatter::Numeric do
+  let(:proxy) do
+    Class.new do
+      include Fixy::Formatter::Numeric
+    end.new
+  end
+
+  describe '#format_numeric' do
+    subject(:format_numeric) { proxy.format_numeric(input, length) }
+    let(:length) { 10 }
+
+    context 'when input is nil' do
+      let(:input) { nil }
+      it { is_expected.to eq('0' * length) }
+    end
+
+    context 'when input is non-numeric' do
+      let(:input) { 'Not a num' }
+
+      it 'raises an exception' do
+        expect { format_numeric }.to raise_error(ArgumentError, /only digits/)
+      end
+    end
+
+    context 'when input is too length' do
+      let(:input) { ('5' * (length + 1)).to_i }
+
+      it 'raises an exception' do
+        expect { format_numeric }.to raise_error(ArgumentError, /length/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
NYS MTA-305 wants some 'reserved' entries in the efile that are zero-padded. I thought it would make sense to have numeric fields do that if you don't pass any value.