### PR TITLE
More helpful errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.3.0
+
+* Include class and field name when a field fails validation or raises an error
+
 ## v0.2.0
 
 * Numeric fields can be nil to zero-pad

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.2.3'
+ruby '2.3.4'
 
 # Specify your gem's dependencies in fixy.gemspec
 gemspec

--- a/lib/fixy/record.rb
+++ b/lib/fixy/record.rb
@@ -153,7 +153,7 @@ module Fixy
       value = send(name)
       send("format_#{type}".to_sym, value, size)
     rescue => e
-      raise e, "#{e.message} (#{self.class.name}##{name})"
+      raise e, "#{self.class.name}##{name}: #{e.message}"
     end
 
     # Retrieves the list of record fields that were set through the class methods.

--- a/lib/fixy/record.rb
+++ b/lib/fixy/record.rb
@@ -54,13 +54,7 @@ module Fixy
         end
 
         if value.is_a? Proc
-          define_method(name) do
-            begin
-              self.instance_exec(&value)
-            rescue => e
-              raise e, "#{e.message} (field name: #{name})"
-            end
-          end
+          define_method(name) { self.instance_exec(&value) }
         else
           define_method(name) { value }
         end
@@ -137,10 +131,8 @@ module Fixy
         raise StandardError, "Undefined field for position #{current_position}" unless field
 
         # We will first retrieve the value, then format it
-        method          = field[:name]
-        value           = send(method)
-        formatted_value = format_value(value, field[:size], field[:type])
-        formatted_value = decorator.field(formatted_value, current_record, current_position, method, field[:size], field[:type])
+        formatted_value = format_value(field[:name], field[:size], field[:type])
+        formatted_value = decorator.field(formatted_value, current_record, current_position, field[:name], field[:size], field[:type])
 
         output << formatted_value
         current_position = field[:to] + 1
@@ -157,8 +149,11 @@ module Fixy
     private
 
     # Format value with user defined formatters.
-    def format_value(value, size, type)
+    def format_value(name, size, type)
+      value = send(name)
       send("format_#{type}".to_sym, value, size)
+    rescue => e
+      raise e, "#{e.message} (#{self.class.name}##{name})"
     end
 
     # Retrieves the list of record fields that were set through the class methods.

--- a/lib/fixy/version.rb
+++ b/lib/fixy/version.rb
@@ -1,3 +1,3 @@
 module Fixy
-  VERSION = '0.2.1'
+  VERSION = '0.3.0'
 end

--- a/spec/fixy/record_spec.rb
+++ b/spec/fixy/record_spec.rb
@@ -219,14 +219,30 @@ describe 'Generating a Record' do
   end
 
   context 'when the value proc raises an error' do
-    class PersonRecordWithError < Fixy::Record
+    class PersonRecordWithErrorA < Fixy::Record
       include Fixy::Formatter::Alphanumeric
       set_record_length 20
       set_line_ending Fixy::Record::LINE_ENDING_CRLF
-      field(:description , 20, '1-20', :alphanumeric) { non_existant_var }
+      field(:description, 20, '1-20', :alphanumeric) { non_existant_var }
     end
-    it 'includes the field name in the error message' do
-      expect { PersonRecordWithError.new.generate }.to raise_error(NameError, /field name: description/)
+    it 'includes the class and field name in the error message' do
+      expect { PersonRecordWithErrorA.new.generate }.to raise_error(
+        NameError, /PersonRecordWithErrorA#description/
+      )
+    end
+  end
+
+  context 'when the built-in formatter raises an error' do
+    class PersonRecordWithErrorB < Fixy::Record
+      include Fixy::Formatter::Numeric
+      set_record_length 20
+      set_line_ending Fixy::Record::LINE_ENDING_CRLF
+      field(:description, 20, '1-20', :numeric) { -6 }
+    end
+    it 'includes the class and field name in the error message' do
+      expect { PersonRecordWithErrorB.new.generate }.to raise_error(
+        ArgumentError, "Invalid Input (only digits are accepted) (input: -6) (PersonRecordWithErrorB#description)"
+      )
     end
   end
 end

--- a/spec/fixy/record_spec.rb
+++ b/spec/fixy/record_spec.rb
@@ -227,7 +227,7 @@ describe 'Generating a Record' do
     end
     it 'includes the class and field name in the error message' do
       expect { PersonRecordWithErrorA.new.generate }.to raise_error(
-        NameError, /PersonRecordWithErrorA#description/
+        NameError, /^PersonRecordWithErrorA#description/
       )
     end
   end
@@ -241,7 +241,7 @@ describe 'Generating a Record' do
     end
     it 'includes the class and field name in the error message' do
       expect { PersonRecordWithErrorB.new.generate }.to raise_error(
-        ArgumentError, "Invalid Input (only digits are accepted) (input: -6) (PersonRecordWithErrorB#description)"
+        ArgumentError, "PersonRecordWithErrorB#description: Invalid Input (only digits are accepted) (input: -6)"
       )
     end
   end


### PR DESCRIPTION
Currently when a field-level validation fails you get the failure message but no information on what field or even class this happened on. This is especially difficult when there are many nested Fixy records. This PR adds the class and field name to the error message.

**Before**:
```
ArgumentError: Invalid Input (only digits are accepted) (input: -6)
```

**After**
```
ArgumentError: Invalid Input (only digits are accepted) (input: -6) (Penguin::Forms::OhioSuta::Records::RecordF#total_amount_paid_cents)
```