### PR TITLE
Performance improvements related to string concatenation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.6.0
+
+* Performace improvements to use list append instead of string concatenation.
+
 ## v0.5.0
 
 * Make performace improvements related to string concatenation.

--- a/lib/fixy/document.rb
+++ b/lib/fixy/document.rb
@@ -1,7 +1,7 @@
 module Fixy
   class Document
 
-    attr_accessor :content, :debug_mode
+    attr_accessor :debug_mode
 
     def generate_to_file(path, debug = false)
       File.open(path, 'w') do |file|
@@ -11,12 +11,16 @@ module Fixy
 
     def generate(debug = false)
       @debug_mode = debug
-      @content = ''
+      @contents = []
 
       # Generate document based on user logic.
       build
 
-      decorator.document(@content)
+      decorator.document(@contents.join)
+    end
+
+    def content
+      @contents.join
     end
 
     private
@@ -30,15 +34,15 @@ module Fixy
     end
 
     def prepend_record(record)
-      @content = record.generate(debug_mode) << @content
+      @contents.insert(0, record.generate(debug_mode))
     end
 
     def append_record(record)
-      @content << record.generate(debug_mode)
+      @contents << record.generate(debug_mode)
     end
 
     def parse_record(klass, record)
-      @content << klass.parse(record, debug_mode)[:record]
+      @contents << klass.parse(record, debug_mode)[:record]
     end
   end
 end

--- a/lib/fixy/formatter/alphanumeric.rb
+++ b/lib/fixy/formatter/alphanumeric.rb
@@ -11,21 +11,25 @@ module Fixy
 
       def format_alphanumeric(input, byte_width)
         input_string = String.new(input.to_s).tr "#{self.class::LINE_ENDING_CRLF}#{line_ending}", ''
-        result = ''
+        result = []
+        bytesize = 0
 
         if input_string.bytesize <= byte_width
           result << input_string
+          bytesize = input_string.bytesize
         else
           input_string.each_char do |char|
-            if result.bytesize + char.bytesize <= byte_width
+            if bytesize + char.bytesize <= byte_width
               result << char
+              bytesize += char.bytesize
             else
               break
             end
           end
         end
 
-        result << (' ' * (byte_width - result.bytesize))
+        result << (' ' * (byte_width - bytesize))
+        result.join
       end
     end
   end

--- a/lib/fixy/record.rb
+++ b/lib/fixy/record.rb
@@ -87,7 +87,7 @@ module Fixy
 
         decorator = debug ? Fixy::Decorator::Debug : Fixy::Decorator::Default
         fields = []
-        output = ''
+        output = []
         current_position = 1
         current_record = 1
 
@@ -114,14 +114,14 @@ module Fixy
         # Documentation mandates that every record ends with new line.
         output << line_ending
 
-        { fields: fields, record: decorator.record(output) }
+        { fields: fields, record: decorator.record(output.join) }
       end
     end
 
     # Generate the entry based on the record structure
     def generate(debug = false)
       decorator = debug ? Fixy::Decorator::Debug : Fixy::Decorator::Default
-      output = ''
+      output = []
       current_position = 1
       current_record = 1
 
@@ -143,7 +143,7 @@ module Fixy
       output << line_ending
 
       # All ready. In the words of Mr. Peters: "Take it and go!"
-      decorator.record(output)
+      decorator.record(output.join)
     end
 
     private

--- a/lib/fixy/version.rb
+++ b/lib/fixy/version.rb
@@ -1,3 +1,3 @@
 module Fixy
-  VERSION = '0.5.0'
+  VERSION = '0.6.0'
 end


### PR DESCRIPTION
[slack thread with more details about the problem](https://gustohq.slack.com/archives/C03GQ72J4MA/p1741270795343699)

zp upgraded to ruby 3.4.2 from 3.3.5 which caused performance regression in nacha file content generation process which relies on fixy

string append is supposed to be faster than list but for some reason, there is a performance degradation after upgrading to ruby 3.4.2. list append followed by join seems to be faster in local testing where I imported nacha file https://app.gusto.com/panda/nacha_files/7756732091801973 with almost 25K entries and ran content generation locally.

```
--list append (current PR)
11:26:37.815AM  INFO | Generated file contents for NachaFile #7756732091801973, contents size: 2510755 bytes
=> [#<Benchmark::Tms:0x0000000357a3f840 @cstime=0.0, @cutime=0.0, @label="content generation", @real=104.65053700003773, @stime=4.265163000000001, @total=93.92097199999999, @utime=89.65580899999999>]

--string append (version live in prod) 
11:32:27.352AM  INFO | Generated file contents for NachaFile #7756732091801973, contents size: 2510755 bytes
content generation167.825551   9.766999 177.592550 (197.888986)
=> [#<Benchmark::Tms:0x0000000350116040 @cstime=0.0, @cutime=0.0, @label="content generation", @real=197.88898599997628, @stime=9.766999, @total=177.59255, @utime=167.825551>]

--list append (current PR)
11:37:03.168AM  INFO | Generated file contents for NachaFile #7756732091801973, contents size: 2510755 bytes
content generation 87.967119   3.609446  91.576565 ( 99.687945)
=> [#<Benchmark::Tms:0x000000033b15ccd0 @cstime=0.0, @cutime=0.0, @label="content generation", @real=99.6879450000124, @stime=3.6094459999999993, @total=91.57656500000002, @utime=87.96711900000001>]
```

also, I downloaded contents from s3 and it is the same, only diff is a field that is based on current time. I renamed files locally for clarity
```
➜  Downloads diff 7756732091801973_current_fixy 7756732091801973_perf_optimizations
1c1
< 101 02100002191388640002503071129L094101JPMorgan Chase         Gusto/Zenpayroll, Inc. 250307
---
> 101 02100002191388640002503071135L094101JPMorgan Chase         Gusto/Zenpayroll, Inc. 250307
```