### PR TITLE
Make contents variable attr_accessor

### DIFF
--- a/lib/fixy/document.rb
+++ b/lib/fixy/document.rb
@@ -1,7 +1,7 @@
 module Fixy
   class Document
 
-    attr_accessor :debug_mode
+    attr_accessor :contents, :debug_mode
 
     def generate_to_file(path, debug = false)
       File.open(path, 'w') do |file|


### PR DESCRIPTION
followup to https://github.com/Gusto/fixy/pull/16,

I tried upgrading zp but nacha files preview is failing as its assign `contents`, leaving version the same