### PR TITLE
Exclude CI/dev files from built gem and update homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v0.6.2
+
+* Update gemspec to use explicit file list instead of `git ls-files`
+* Update gem ownership metadata to Gusto
+
+## v0.6.1
+
+* Make `contents` an `attr_accessor` for performance improvements
+
 ## v0.6.0
 
 * Performace improvements to use list append instead of string concatenation.

--- a/fixy.gemspec
+++ b/fixy.gemspec
@@ -12,8 +12,15 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/gusto/fixy'
   spec.license       = 'MIT'
 
-  excluded_files     = ['Dockerfile', 'docker-compose.yml', 'solano.yml']
-  spec.files         = `git ls-files`.split($/).reject { |f| f.start_with?('.buildkite/') || excluded_files.include?(f) }
+  spec.files         = Dir.chdir(__dir__) do
+    Dir.glob([
+               '*.gemspec',
+               'LICENSE.txt',
+               'README.md',
+               'CHANGELOG.md',
+               'lib/**/*'
+             ])
+  end
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']

--- a/fixy.gemspec
+++ b/fixy.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
   spec.metadata      = {
     'source_code_uri' => 'https://github.com/gusto/fixy',
-    'changelog_uri'   => 'https://github.com/Gusto/fixy/blob/master/CHANGELOG.md'
+    'changelog_uri'   => 'https://github.com/gusto/fixy/blob/master/CHANGELOG.md'
   }
 
   spec.files         = Dir.chdir(__dir__) do

--- a/fixy.gemspec
+++ b/fixy.gemspec
@@ -5,8 +5,8 @@ require 'fixy/version'
 Gem::Specification.new do |spec|
   spec.name          = 'fixy'
   spec.version       = Fixy::VERSION
-  spec.authors       = ['Omar Skalli']
-  spec.email         = ['omar@zenpayroll.com']
+  spec.authors       = ['Gusto']
+  spec.email         = ['gusto-opensource-buildkite@gusto.com']
   spec.description   = %q{Library for generating fixed width flat files.}
   spec.summary       = %q{Provides a DSL for defining, generating, and debugging fixed width documents.}
   spec.homepage      = 'https://github.com/gusto/fixy'

--- a/fixy.gemspec
+++ b/fixy.gemspec
@@ -11,6 +11,10 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{Provides a DSL for defining, generating, and debugging fixed width documents.}
   spec.homepage      = 'https://github.com/gusto/fixy'
   spec.license       = 'MIT'
+  spec.metadata      = {
+    'source_code_uri' => 'https://github.com/gusto/fixy',
+    'changelog_uri'   => 'https://github.com/Gusto/fixy/blob/master/CHANGELOG.md'
+  }
 
   spec.files         = Dir.chdir(__dir__) do
     Dir.glob([

--- a/fixy.gemspec
+++ b/fixy.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.version       = Fixy::VERSION
   spec.authors       = ['Gusto']
   spec.email         = ['gusto-opensource-buildkite@gusto.com']
-  spec.description   = %q{Library for generating fixed width flat files.}
+  spec.description   = %q{Library for generating fixed width flat files. Fork of OmarSkalli/fixy.}
   spec.summary       = %q{Provides a DSL for defining, generating, and debugging fixed width documents.}
   spec.homepage      = 'https://github.com/gusto/fixy'
   spec.license       = 'MIT'

--- a/fixy.gemspec
+++ b/fixy.gemspec
@@ -9,10 +9,11 @@ Gem::Specification.new do |spec|
   spec.email         = ['omar@zenpayroll.com']
   spec.description   = %q{Library for generating fixed width flat files.}
   spec.summary       = %q{Provides a DSL for defining, generating, and debugging fixed width documents.}
-  spec.homepage      = 'https://github.com/chetane/fixy'
+  spec.homepage      = 'https://github.com/gusto/fixy'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files`.split($/)
+  excluded_files     = ['Dockerfile', 'docker-compose.yml', 'solano.yml']
+  spec.files         = `git ls-files`.split($/).reject { |f| f.start_with?('.buildkite/') || excluded_files.include?(f) }
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']

--- a/fixy.gemspec
+++ b/fixy.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
                'README.md',
                'CHANGELOG.md',
                'lib/**/*'
-             ])
+             ]).select { |f| File.file?(f) }
   end
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})

--- a/fixy.gemspec
+++ b/fixy.gemspec
@@ -5,8 +5,8 @@ require 'fixy/version'
 Gem::Specification.new do |spec|
   spec.name          = 'fixy'
   spec.version       = Fixy::VERSION
-  spec.authors       = ['Gusto']
-  spec.email         = ['gusto-opensource-buildkite@gusto.com']
+  spec.authors       = ['Omar Skalli', 'Gusto']
+  spec.email         = ['omar@zenpayroll.com', 'gusto-opensource-buildkite@gusto.com']
   spec.description   = %q{Library for generating fixed width flat files.}
   spec.summary       = %q{Provides a DSL for defining, generating, and debugging fixed width documents.}
   spec.homepage      = 'https://github.com/gusto/fixy'

--- a/fixy.gemspec
+++ b/fixy.gemspec
@@ -5,8 +5,8 @@ require 'fixy/version'
 Gem::Specification.new do |spec|
   spec.name          = 'fixy'
   spec.version       = Fixy::VERSION
-  spec.authors       = ['Omar Skalli', 'Gusto']
-  spec.email         = ['omar@zenpayroll.com', 'gusto-opensource-buildkite@gusto.com']
+  spec.authors       = ['Gusto']
+  spec.email         = ['gusto-opensource-buildkite@gusto.com']
   spec.description   = %q{Library for generating fixed width flat files.}
   spec.summary       = %q{Provides a DSL for defining, generating, and debugging fixed width documents.}
   spec.homepage      = 'https://github.com/gusto/fixy'

--- a/lib/fixy/version.rb
+++ b/lib/fixy/version.rb
@@ -1,3 +1,3 @@
 module Fixy
-  VERSION = '0.6.1'
+  VERSION = '0.6.2'
 end


### PR DESCRIPTION
## Summary
- Filter `.buildkite/pipeline.yml`, `Dockerfile`, `docker-compose.yml`, and `solano.yml` out of `spec.files` so they don't ship in the published gem
- Update `spec.homepage` to point at the current repo (`gusto/fixy`) instead of the original `chetane/fixy`

## Test plan
- [ ] `gem build fixy.gemspec` and inspect the resulting `.gem` to confirm excluded files are absent and `lib/`, README, CHANGELOG, LICENSE, Rakefile, Gemfile remain