### PR TITLE
Fix ambiguous regexp warning in record.rb, bump to v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.6.3
+
+* Fix ambiguous `/` warning in `record.rb` by wrapping regexp in parentheses
+
 ## v0.6.2
 
 * Update gemspec to use explicit file list instead of `git ls-files`

--- a/lib/fixy/record.rb
+++ b/lib/fixy/record.rb
@@ -16,7 +16,7 @@ module Fixy
 
       def field(name, size, range, type, &block)
         @record_fields ||= default_record_fields
-        range_matches = range.match /^(\d+)(?:-(\d+))?$/
+        range_matches = range.match(/^(\d+)(?:-(\d+))?$/)
 
         # Make sure inputs are valid, we rather fail early than behave unexpectedly later.
         raise ArgumentError, "Name '#{name}' is not a symbol"  unless name.is_a? Symbol

--- a/lib/fixy/version.rb
+++ b/lib/fixy/version.rb
@@ -1,3 +1,3 @@
 module Fixy
-  VERSION = '0.6.2'
+  VERSION = '0.6.3'
 end


### PR DESCRIPTION
## Summary

- Wraps the regexp literal in `record.rb:19` in parentheses to silence the Ruby warning: `ambiguous `/`; wrap regexp in parentheses or add a space after `/` operator`
- Bumps version from 0.6.2 → 0.6.3

## Context

Ruby emits this warning when a `/` after a method call is ambiguous between regexp and division. The fix is purely syntactic — no behavioral change. Existing tests in `spec/fixy/record_spec.rb` already exercise the `field` method with range strings and cover this code path.