### PR TITLE
Remove travis ci reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://travis-ci.org/Chetane/fixy.svg?branch=master)](https://travis-ci.org/Chetane/fixy)
-
 ## fixy
 
 Library for generating fixed width flat file documents. 


### PR DESCRIPTION
I had cleaned up a few things in this repository a few months ago, and had this sitting around - remove old travis CI build reference in README