### PR TITLE
Migrate fixy gems (publish + reads) from Gemstash/RubyGems to Cloudsmith

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,10 @@ steps:
   prompt: 'Publish this gem to the server using Fixy::VERSION as the version?'
   branches: 'main'
 - name: ':ruby: Build & Publish gem'
-  command: 'docker-compose build && docker-compose --project-name $BUILDKITE_JOB_ID run app sh -c "gem build fixy.gemspec && gem push --config-file ./.gem/credentials --key gemstash --host https://gemstash.zp-int.com/private fixy-*.gem"'
+  command: 'docker-compose build && docker-compose --project-name $BUILDKITE_JOB_ID run -e CLOUDSMITH_API_KEY app sh .buildkite/publish.sh'
   agents:
     queue: gemstash-publish
   branches: 'main'
+  plugins:
+  - ssh://git@github.com/Gusto/cloudsmith-auth-buildkite-plugin.git#v2.2.0:
+      mode: publish

--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -1,8 +1,28 @@
 #!/usr/bin/env bash
-set -x -e
+set -e
 
 # CLOUDSMITH_API_KEY is minted by the cloudsmith-auth Buildkite plugin
 # (publish mode) and passed into this container via `docker-compose run -e`.
+: "${CLOUDSMITH_API_KEY:?ERROR: CLOUDSMITH_API_KEY is required}"
+
 gem build fixy.gemspec
+
+VERSION="$(ruby -e "puts Gem::Specification.load('fixy.gemspec').version")"
+GEM_FILE="fixy-${VERSION}.gem"
+
+# Idempotency: skip the push only if THIS exact name+version is already Completed in Cloudsmith.
+# Cloudsmith's ?query= is a fuzzy token search (version:1.2.3 can match 1.2.30; name matches
+# related packages), so we parse the JSON and require an exact name+version+status match rather
+# than grepping the whole response. Best-effort: on any lookup failure (empty/401/parse error)
+# we fall through to the push, since the push is the source of truth.
+if curl -sS -H "X-Api-Key: ${CLOUDSMITH_API_KEY}" \
+     "https://api.cloudsmith.io/v1/packages/gusto/gusto/?query=name:fixy+version:${VERSION}" 2>/dev/null \
+   | ruby -rjson -e 'pkgs = (JSON.parse(STDIN.read) rescue nil); exit(pkgs.is_a?(Array) && pkgs.any? { |p| p["name"] == "fixy" && p["version"] == ARGV[0] && p["status_str"] == "Completed" } ? 0 : 1)' "$VERSION"; then
+  echo "fixy ${VERSION} is already published to Cloudsmith - skipping push."
+  exit 0
+fi
+
+# gem push reads the token via GEM_HOST_API_KEY (not argv); no `set -x` here so the Bearer
+# token is never echoed into the build log.
 GEM_HOST_API_KEY="Bearer ${CLOUDSMITH_API_KEY}" \
-  gem push --host https://ruby.cloudsmith.io/gusto/gusto fixy-*.gem
+  gem push --host https://ruby.cloudsmith.io/gusto/gusto "${GEM_FILE}"

--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -x -e
+
+# CLOUDSMITH_API_KEY is minted by the cloudsmith-auth Buildkite plugin
+# (publish mode) and passed into this container via `docker-compose run -e`.
+gem build fixy.gemspec
+GEM_HOST_API_KEY="Bearer ${CLOUDSMITH_API_KEY}" \
+  gem push --host https://ruby.cloudsmith.io/gusto/gusto fixy-*.gem

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source 'https://dl.cloudsmith.io/basic/gusto/gusto/ruby/'
 ruby '3.2.2'
 
 # Specify your gem's dependencies in fixy.gemspec

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,3 @@ services:
   app:
     build:
       context: .
-    volumes:
-    - .gem/credentials:/home/gusto/.gem/credentials
-    - ~/bin/gemstash_safe_publish.sh:/home/gusto/bin/gemstash_safe_publish.sh

--- a/fixy.gemspec
+++ b/fixy.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/gusto/fixy'
   spec.license       = 'MIT'
   spec.metadata      = {
+    'allowed_push_host' => 'https://ruby.cloudsmith.io/gusto/gusto',
     'source_code_uri' => 'https://github.com/gusto/fixy',
     'changelog_uri'   => 'https://github.com/gusto/fixy/blob/main/CHANGELOG.md'
   }


### PR DESCRIPTION
## What

Migrates fixy's gems off the internal Gemstash server (`gemstash.zp-int.com`), which is being decommissioned, onto Cloudsmith — both the **publish** path and the **read** source — matching the mechanism used by other Gusto gems (e.g. `migrant-rails`, `gusto-ruby-foundation`, `hawaiian-ice`).

## Changes

### Publish (Gemstash → Cloudsmith)
- **`.buildkite/pipeline.yml`** — the publish step uses the [`cloudsmith-auth-buildkite-plugin`](https://github.com/Gusto/cloudsmith-auth-buildkite-plugin) in `mode: publish` to mint a short-lived `CLOUDSMITH_API_KEY`, passes it into the `app` container via `docker-compose run -e`, and runs the new publish script. The `gemstash-publish` agent queue is retained (unchanged org-wide after the migration).
- **`.buildkite/publish.sh`** (new) — builds the gem and pushes it with `GEM_HOST_API_KEY="Bearer $CLOUDSMITH_API_KEY" gem push --host https://ruby.cloudsmith.io/gusto/gusto`.
- **`fixy.gemspec`** — adds `allowed_push_host` pointing at the Cloudsmith repo, so the gem can't be accidentally pushed to rubygems.org.
- **`docker-compose.yml`** — drops the now-unused Gemstash volume mounts (`.gem/credentials` and the host-side `gemstash_safe_publish.sh`); Cloudsmith auth is entirely env-var based.

### Publish hardening (`publish.sh`)
- **Idempotent** — skips the push when this exact name+version is already `Completed` in Cloudsmith, so a re-run (retry, or the release block clicked twice on the same `Fixy::VERSION`) doesn't fail on a duplicate. Requires an exact version match (not any package in Cloudsmith's fuzzy `?query=` response) and falls through to the push on any lookup failure.
- **Fails fast** with a clear message if `CLOUDSMITH_API_KEY` is missing, instead of pushing an empty Bearer.
- Runs under `set -e` (not `set -x`) so the Bearer token is never echoed into the build log, and pushes the exact `fixy-${VERSION}.gem` rather than a glob.

### Read (RubyGems → Cloudsmith)
- **`Gemfile`** — points the source at the Cloudsmith Ruby registry so reads no longer hit rubygems.org directly. fixy has no committed `Gemfile.lock`, so there's nothing to re-resolve. Anyone running `bundle install` will need Cloudsmith read auth (`BUNDLE_DL__CLOUDSMITH__IO`), same as every other migrated repo.

## Notes

- No secrets are committed — the API key is minted at build time by the plugin and referenced only via env var.
- The old flow pushed to the internal host `gemstash.zp-int.com`; that reference is fully removed.
