### PR TITLE
Give the Docker build Cloudsmith read auth (fix bundle install on main)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,6 +3,9 @@ steps:
   command: 'docker-compose build && docker-compose --project-name $BUILDKITE_JOB_ID run app bundle exec rake spec'
   agents:
     queue: single
+  plugins:
+  - ssh://git@github.com/Gusto/cloudsmith-auth-buildkite-plugin.git#v2.2.0:
+      mode: pull
 - wait
 - block: ':rocket: Publish to Gem Server'
   prompt: 'Publish this gem to the server using Fixy::VERSION as the version?'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.10.0
 FROM ruby:3.2.2-slim
 
 WORKDIR /home/gusto
@@ -5,7 +6,12 @@ WORKDIR /home/gusto
 ADD . /home/gusto/
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  build-essential\
+  build-essential \
   git
 RUN gem install bundler:2.1.4
-RUN bundle install
+# The Cloudsmith read key is provided as a BuildKit secret (mounted only for
+# this step, never baked into a layer) so bundler can authenticate to the
+# Cloudsmith Ruby source.
+RUN --mount=type=secret,id=cloudsmith_api_key,env=CLOUDSMITH_API_KEY \
+  BUNDLE_DL__CLOUDSMITH__IO="token:${CLOUDSMITH_API_KEY}" \
+  bundle install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,13 @@
-version: '2'
 services:
   app:
     build:
       context: .
+      secrets:
+        - cloudsmith_api_key
+    environment:
+      - CLOUDSMITH_API_KEY
+      - BUNDLE_DL__CLOUDSMITH__IO
+
+secrets:
+  cloudsmith_api_key:
+    environment: CLOUDSMITH_API_KEY


### PR DESCRIPTION
## Why

`main` is red ([build #48](https://buildkite.com/gusto/fixy/builds/48)). After the Gemfile source moved to Cloudsmith (#23), the Test step's `docker-compose build` fails at `RUN bundle install`:

```
Authentication is required for dl.cloudsmith.io.
... store the credentials in the BUNDLE_DL__CLOUDSMITH__IO environment ...
exit code: 17
```

`bundle install` runs **inside the image build**, where the cloudsmith-auth plugin's `CLOUDSMITH_API_KEY` env var can't reach (Docker isolates the build env). It needs a BuildKit `--secret` mount — the same pattern `deprecation_helper` / `explicit_activerecord` use.

## Changes

- **`Dockerfile`** — `# syntax` directive + `RUN --mount=type=secret,id=cloudsmith_api_key,env=CLOUDSMITH_API_KEY BUNDLE_DL__CLOUDSMITH__IO="token:\${CLOUDSMITH_API_KEY}" bundle install`. The key is mounted only for that step, never baked into a layer.
- **`docker-compose.yml`** — declares the `cloudsmith_api_key` build secret, sourced from the `CLOUDSMITH_API_KEY` env var (Compose v2).
- **`.buildkite/pipeline.yml`** — adds the `cloudsmith-auth` plugin (`mode: pull`) to the Test step so the key is minted on the agent. The Publish step already mints a read+write key via `mode: publish`, so its build is covered.

The `gemstash-publish` queue name is unchanged.